### PR TITLE
A note about where to run elm-reactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,5 @@ There's an example with a country picker in the `example` directory.
 cd example
 elm-reactor
 ```
+
+**Note** You **must** run `elm-reactor` from within the `example` directory to use the correct package dependencies.


### PR DESCRIPTION
Attempt to make it more clear that you **need** to run `elm-reactor` from the `example` directory.